### PR TITLE
Added regex sub rule for String.format

### DIFF
--- a/java2python/config/default.py
+++ b/java2python/config/default.py
@@ -189,6 +189,7 @@ expressionCastHandler = basic.castDrop
 moduleOutputSubs = [
     (r'System\.out\.println\((.*)\)', r'print \1'),
     (r'System\.out\.print_\((.*?)\)', r'print \1,'),
+    (r'String\.format\(\"(.*)\" *, *(.*)\)', r'"\1" % (\2)'),
     (r'(.*?)\.equals\((.*?)\)', r'\1 == \2'),
     (r'(.*?)\.equalsIgnoreCase\((.*?)\)', r'\1.lower() == \2.lower()'),
     (r'([\w.]+)\.size\(\)', r'len(\1)'),

--- a/test/Format.java
+++ b/test/Format.java
@@ -1,0 +1,9 @@
+public class Format {
+  public static void main(String[] args) {
+    int i = 22;
+    String s = "text";
+    String r = String.format("> (%d) %s", i, s);
+
+    System.out.println(r);
+  }
+}


### PR DESCRIPTION
Added a new output substitution regex rule to handle `String.format`.

Turns this:

```
String.format("(%d) %s", i, s);
```

into this:

```
"(%d) %s" % (i, s)
```

Does not handle the whole Java specs about `Formatter`, like `%1$d`

Test case added.
