### PR TITLE
docs: Fix a few typos

### DIFF
--- a/java2python/compiler/template.py
+++ b/java2python/compiler/template.py
@@ -146,7 +146,7 @@ class Base(object):
         return reduce(lambda v, func:func(self, v), handlers, self.dumps(-1))
 
     def adopt(self, child, index=-1):
-        """ Adds child to this objecs children and sets the childs parent. """
+        """ Adds child to this objects children and sets the childs parent. """
         self.children.insert(index, child)
         child.parent = self
 

--- a/java2python/compiler/visitor.py
+++ b/java2python/compiler/visitor.py
@@ -868,7 +868,7 @@ class Expression(Base):
         self.pushRight('self')
 
     def acceptQuestion(self, node, memo):
-        """ Accept and process a terinary expression. """
+        """ Accept and process a ternary expression. """
         expr = self.factory.expr
         self.fs = FS.l + ' if ' + FS.r
         self.left = expr(parent=self)

--- a/java2python/config/default.py
+++ b/java2python/config/default.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This is the default configuration file for java2python.  Unless
-# explicity disabled with the '-n' or '--nodefaults' option, the j2py
+# explicitly disabled with the '-n' or '--nodefaults' option, the j2py
 # script will import this module for runtime configuration.
 
 from java2python.mod import basic, transform

--- a/java2python/lang/base.py
+++ b/java2python/lang/base.py
@@ -114,7 +114,7 @@ tokens = Tokens()
 
 
 class TreeAdaptor(CommonTreeAdaptor):
-    """ TreeAdaptor -> defered tree node creator (for parsers). """
+    """ TreeAdaptor -> deferred tree node creator (for parsers). """
 
     def __init__(self, lexer, parser):
         # CommonTreeAdaptor doesn't need to be __init__'ed

--- a/java2python/mod/__init__.py
+++ b/java2python/mod/__init__.py
@@ -7,7 +7,7 @@
 # sprinkling generated source with docstrings, comments, decorators,
 # etc.
 #
-# The java2python.mod.inclues module contains functions that the
+# The java2python.mod.include module contains functions that the
 # library will include directly -- as source code -- in the generated
 # output.
 #

--- a/test/configs/Interface3.py
+++ b/test/configs/Interface3.py
@@ -29,7 +29,7 @@ interfaceBaseHandlers = [
 
 # the parser adds implemented interfaces to the class bases list.
 # this handler checks to see if any of those bases are interfaces, and
-# if so, supresses them in favor of 'object' as the only base:
+# if so, suppresses them in favor of 'object' as the only base:
 classBaseHandlers = [
     basic.zopeImplementsClassBases,
 ]
@@ -42,7 +42,7 @@ classHeadHandlers = [
 ]
 
 
-# this handler supresses the "self" parameter on method signatures for
+# this handler suppresses the "self" parameter on method signatures for
 # zope Interface definitions:
 methodParamHandlers = [
     basic.zopeInterfaceMethodParams,


### PR DESCRIPTION
There are small typos in:
- java2python/compiler/template.py
- java2python/compiler/visitor.py
- java2python/config/default.py
- java2python/lang/base.py
- java2python/mod/__init__.py
- test/configs/Interface3.py

Fixes:
- Should read `suppresses` rather than `supresses`.
- Should read `ternary` rather than `terinary`.
- Should read `objects` rather than `objecs`.
- Should read `include` rather than `inclues`.
- Should read `explicitly` rather than `explicity`.
- Should read `deferred` rather than `defered`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md